### PR TITLE
[WIP] Support Turbolinks & non-Turbolinks apps reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Payola adheres to [Semantic Versioning](http://semver.org/).
 
 All notable changes to Payola will be documented in this file.
 
+## Unreleased
+[Full Changelog](https://github.com/peterkeen/payola/compare/v1.5.0...HEAD)
+
+### Enhancements
+- Support Turbolinks & non-Turbolinks apps reliably. #254
+
 ## v1.5.0 - 2016-10-27
 [Full Changelog](https://github.com/peterkeen/payola/compare/v1.4.0...v1.5.0)
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ Optionally, tell Stripe about your application. Add this as a webhook in your [S
 https://your.website.example.com/payola/events
 ```
 
-### Disable Turbolinks
-
-Payola does not currently play nice with turbolinks. Disable it by removing the turbolinks include in your `application.js`.
-
 ## Additional Setup Resources
 
 

--- a/app/assets/javascripts/payola/checkout_button.js
+++ b/app/assets/javascripts/payola/checkout_button.js
@@ -1,9 +1,12 @@
 var PayolaCheckout = {
     initialize: function() {
-        $('.payola-checkout-button').on('click', function(e) {
-            e.preventDefault();
-            PayolaCheckout.handleCheckoutButtonClick($(this));
-        });
+        $(document).off('click.payola-checkout-button').on(
+            'click.payola-checkout-button', '.payola-checkout-button',
+            function(e) {
+                e.preventDefault();
+                PayolaCheckout.handleCheckoutButtonClick($(this));
+            }
+        );
     },
 
     handleCheckoutButtonClick: function(button) {
@@ -94,8 +97,4 @@ var PayolaCheckout = {
     }
 };
 
-if ('undefined' !== typeof Turbolinks) {
-    $(document).on('page:change', PayolaCheckout.initialize);
-} else {
-    $(document).ready(PayolaCheckout.initialize);
-}
+PayolaCheckout.initialize();

--- a/app/assets/javascripts/payola/form.js
+++ b/app/assets/javascripts/payola/form.js
@@ -1,8 +1,11 @@
 var PayolaPaymentForm = {
     initialize: function() {
-        $('.payola-payment-form').on('submit', function() {
-            return PayolaPaymentForm.handleSubmit($(this));
-        });
+        $(document).off('submit.payola-payment-form').on(
+            'submit.payola-payment-form', '.payola-payment-form',
+            function() {
+                return PayolaPaymentForm.handleSubmit($(this));
+            }
+        );
     },
 
     handleSubmit: function(form) {
@@ -28,7 +31,7 @@ var PayolaPaymentForm = {
             data_form.append($('<input type="hidden" name="stripeToken">').val(response.id));
             data_form.append($('<input type="hidden" name="stripeEmail">').val(email));
             data_form.append(PayolaPaymentForm.authenticityTokenInput());
-            
+
             $.ajax({
                 type: "POST",
                 url: base_path + "/buy/" + product + "/" + permalink,
@@ -74,8 +77,4 @@ var PayolaPaymentForm = {
     }
 };
 
-if ('undefined' !== typeof Turbolinks) {
-    $(document).on('page:change', PayolaPaymentForm.initialize);
-} else {
-    $(document).ready(PayolaPaymentForm.initialize);
-}
+PayolaPaymentForm.initialize();

--- a/app/assets/javascripts/payola/subscription_checkout_button.js
+++ b/app/assets/javascripts/payola/subscription_checkout_button.js
@@ -1,9 +1,12 @@
 var PayolaSubscriptionCheckout = {
     initialize: function() {
-        $('.payola-subscription-checkout-button').on('click', function(e) {
-            e.preventDefault();
-            PayolaSubscriptionCheckout.handleCheckoutButtonClick($(this));
-        });
+        $(document).off('click.payola-subscription-checkout-button').on(
+            'click.payola-subscription-checkout-button', '.payola-subscription-checkout-button',
+            function(e) {
+                e.preventDefault();
+                PayolaSubscriptionCheckout.handleCheckoutButtonClick($(this));
+            }
+        );
     },
 
     handleCheckoutButtonClick: function(button) {
@@ -103,8 +106,4 @@ var PayolaSubscriptionCheckout = {
     }
 };
 
-if ('undefined' !== typeof Turbolinks) {
-    $(document).on('page:change', PayolaSubscriptionCheckout.initialize);
-} else {
-    $(document).ready(PayolaSubscriptionCheckout.initialize);
-}
+PayolaSubscriptionCheckout.initialize();

--- a/app/assets/javascripts/payola/subscription_form_onestep.js
+++ b/app/assets/javascripts/payola/subscription_form_onestep.js
@@ -1,8 +1,11 @@
 var PayolaOnestepSubscriptionForm = {
     initialize: function() {
-        $('.payola-onestep-subscription-form').on('submit', function() {
-            return PayolaOnestepSubscriptionForm.handleSubmit($(this));
-        });
+        $(document).off('submit.payola-onestep-subscription-form').on(
+            'submit.payola-onestep-subscription-form', '.payola-onestep-subscription-form',
+            function() {
+                return PayolaOnestepSubscriptionForm.handleSubmit($(this));
+            }
+        );
     },
 
     handleSubmit: function(form) {
@@ -117,8 +120,4 @@ var PayolaOnestepSubscriptionForm = {
     }
 };
 
-if ('undefined' !== typeof Turbolinks) {
-    $(document).on('page:change', PayolaOnestepSubscriptionForm.initialize);
-} else {
-    $(document).ready(PayolaOnestepSubscriptionForm.initialize);
-}
+PayolaOnestepSubscriptionForm.initialize();

--- a/app/assets/javascripts/payola/subscription_form_register.js
+++ b/app/assets/javascripts/payola/subscription_form_register.js
@@ -1,9 +1,12 @@
 var PayolaRegistrationForm = {
     initialize: function() {
-        $('.payola-register-form').on('submit', function(e) {
-            e.preventDefault();
-            return PayolaRegistrationForm.handleSubmit($(this));
-        });
+        $(document).off('submit.payola-register-form').on(
+            'submit.payola-register-form', '.payola-register-form',
+            function() {
+                e.preventDefault();
+                return PayolaRegistrationForm.handleSubmit($(this));
+            }
+        );
     },
 
     handleSubmit: function(form) {
@@ -90,8 +93,4 @@ var PayolaRegistrationForm = {
     }
 };
 
-if ('undefined' !== typeof Turbolinks) {
-    $(document).on('page:change', PayolaRegistrationForm.initialize);
-} else {
-    $(document).ready(PayolaRegistrationForm.initialize);
-}
+PayolaRegistrationForm.initialize();

--- a/app/assets/javascripts/payola/subscription_form_twostep.js
+++ b/app/assets/javascripts/payola/subscription_form_twostep.js
@@ -1,8 +1,11 @@
 var PayolaSubscriptionForm = {
     initialize: function() {
-        $('.payola-subscription-form').on('submit', function() {
-            return PayolaSubscriptionForm.handleSubmit($(this));
-        });
+        $(document).off('submit.payola-subscription-form').on(
+            'submit.payola-subscription-form', '.payola-subscription-form',
+            function() {
+                return PayolaSubscriptionForm.handleSubmit($(this));
+            }
+        );
     },
 
     handleSubmit: function(form) {
@@ -91,8 +94,4 @@ var PayolaSubscriptionForm = {
     }
 };
 
-if ('undefined' !== typeof Turbolinks) {
-    $(document).on('page:change', PayolaSubscriptionForm.initialize);
-} else {
-    $(document).ready(PayolaSubscriptionForm.initialize);
-}
+PayolaSubscriptionForm.initialize();

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -10,3 +10,4 @@ end
 gem 'rspec_junit_formatter'
 
 gem 'rails', git: 'https://github.com/rails/rails', branch: '4-1-stable'
+gem 'rake', '~> 11.1'

--- a/spec/services/payola/invoice_failed_spec.rb
+++ b/spec/services/payola/invoice_failed_spec.rb
@@ -14,7 +14,7 @@ module Payola
 
       sub = create(:subscription, plan: plan, stripe_customer_id: customer.id, stripe_id: customer.subscriptions.first.id)
 
-      charge = Stripe::Charge.create(amount: 100, currency: 'usd', failure_message: 'Failed! OMG!')
+      charge = Stripe::Charge.create(amount: 100, currency: 'usd', failure_message: 'Failed! OMG!', customer: customer.id)
       expect(Stripe::BalanceTransaction).to receive(:retrieve).and_return(OpenStruct.new( amount: 100, fee: 3.29, currency: 'usd' ))
       event = StripeMock.mock_webhook_event('invoice.payment_failed', subscription: sub.stripe_id, charge: charge.id)
 

--- a/spec/services/payola/invoice_paid_spec.rb
+++ b/spec/services/payola/invoice_paid_spec.rb
@@ -34,7 +34,7 @@ module Payola
 
       sub = create(:subscription, plan: plan, stripe_customer_id: customer.id, stripe_id: customer.subscriptions.first.id)
 
-      charge = Stripe::Charge.create(amount: 100, currency: 'usd')
+      charge = Stripe::Charge.create(amount: 100, currency: 'usd', customer: customer.id)
       expect(Stripe::BalanceTransaction).to receive(:retrieve).and_return(OpenStruct.new( amount: 100, fee: 3.29, currency: 'usd' ))
       event = StripeMock.mock_webhook_event('invoice.payment_succeeded', subscription: sub.stripe_id, charge: charge.id)
 


### PR DESCRIPTION
Scripts updated to use this approach:

``` js
// Use jQuery namespaced events to prevent duplicate handlers
var PayolaCheckout = {
  initialize: function() {
    $(document)
      .off('click.payola-checkout-button') // remove any previous handler
      .on('click.payola-checkout-button', '.payola-checkout-button',
          function(e) { ... }
      );
  }
  ...
}
PayolaCheckout.initialize();
```

This approach has all of the following features, some of which have not been
available in any previous approaches:
- Works with or without Turbolinks
- Works with all Turbolinks versions without having to version-sniff
- No reference to the `Turbolinks` object
- Works with Payola forms and buttons that aren't inserted into the DOM until
  after the document is ready
- Avoids accidental duplicate event handlers (say if developer includes
  `<script>` for payola.js twice in the same page). Duplicates avoided using
  `.off()` and [event namespaces](https://api.jquery.com/on/#event-names)
- It is backwards compatible, not requiring changes to HTML

The only disadvantage I can come up with is that multiple event handlers are
attached to the `document` and some of them will be redundant. This was how
Payola originally worked before the Turbolinks-related changes in https://github.com/peterkeen/payola/commit/bfeaa83a01f072bf29419dfe5745e8f834e5b4ce
and https://github.com/peterkeen/payola/commit/2655313d5931ea3ce4e72916966ab5d1aa25653f
and did not cause problems. However, it will be worth recommending developers
only load the `payola-*.js` scripts that are relevant to their app rather than
load all of them so clients are not forced to download more data than needed. By
only loading the relevant `payola-*.js` script(s), redundant event handlers will
not be added to the `document`.
