### PR TITLE
Feature: Added trial_end and coupon to change_subscription_plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Payola will be documented in this file.
 
 ### Enhancements
 - Support Turbolinks & non-Turbolinks apps reliably. #254
+- added support to `ChangeSubscriptionPlan` for `trial_end`
 
 ## v1.5.0 - 2016-10-27
 [Full Changelog](https://github.com/peterkeen/payola/compare/v1.4.0...v1.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Payola will be documented in this file.
 
 ### Enhancements
 - Support Turbolinks & non-Turbolinks apps reliably. #254
-- added support to `ChangeSubscriptionPlan` for `trial_end`
+- added support to `ChangeSubscriptionPlan` for `trial_end` and `coupon`
 
 ## v1.5.0 - 2016-10-27
 [Full Changelog](https://github.com/peterkeen/payola/compare/v1.4.0...v1.5.0)

--- a/app/controllers/payola/subscriptions_controller.rb
+++ b/app/controllers/payola/subscriptions_controller.rb
@@ -27,7 +27,7 @@ module Payola
 
     def change_plan
       @subscription = Subscription.find_by!(guid: params[:guid])
-      Payola::ChangeSubscriptionPlan.call(@subscription, @plan, @quantity)
+      Payola::ChangeSubscriptionPlan.call(@subscription, @plan, @quantity, @trial_end)
 
       confirm_with_message(t('payola.subscriptions.plan_updated'))
     end
@@ -52,6 +52,7 @@ module Payola
     def find_plan_coupon_and_quantity
       find_plan
       find_coupon
+      find_trial_end
       find_quantity
     end
 
@@ -65,6 +66,10 @@ module Payola
 
     def find_coupon
       @coupon = cookies[:cc] || params[:cc] || params[:coupon_code] || params[:coupon]
+    end
+
+    def find_trial_end
+      @trial_end = params[:trial_end]
     end
 
     def find_quantity

--- a/app/controllers/payola/subscriptions_controller.rb
+++ b/app/controllers/payola/subscriptions_controller.rb
@@ -27,7 +27,7 @@ module Payola
 
     def change_plan
       @subscription = Subscription.find_by!(guid: params[:guid])
-      Payola::ChangeSubscriptionPlan.call(@subscription, @plan, @quantity)
+      Payola::ChangeSubscriptionPlan.call(@subscription, @plan, @quantity, @coupon, @trial_end)
 
       confirm_with_message(t('payola.subscriptions.plan_updated'))
     end

--- a/app/controllers/payola/subscriptions_controller.rb
+++ b/app/controllers/payola/subscriptions_controller.rb
@@ -27,7 +27,7 @@ module Payola
 
     def change_plan
       @subscription = Subscription.find_by!(guid: params[:guid])
-      Payola::ChangeSubscriptionPlan.call(@subscription, @plan, @quantity, @trial_end)
+      Payola::ChangeSubscriptionPlan.call(@subscription, @plan, @quantity)
 
       confirm_with_message(t('payola.subscriptions.plan_updated'))
     end

--- a/app/controllers/payola/subscriptions_controller.rb
+++ b/app/controllers/payola/subscriptions_controller.rb
@@ -4,7 +4,7 @@ module Payola
     include Payola::StatusBehavior
     include Payola::AsyncBehavior
 
-    before_action :find_plan_coupon_and_quantity, only: [:create, :change_plan]
+    before_action :find_plan_coupon_quantity_and_trial_end, only: [:create, :change_plan]
     before_action :check_modify_permissions, only: [:destroy, :change_plan, :change_quantity, :update_card]
 
     def show
@@ -49,7 +49,7 @@ module Payola
 
     private
 
-    def find_plan_coupon_and_quantity
+    def find_plan_coupon_quantity_and_trial_end
       find_plan
       find_coupon
       find_trial_end

--- a/app/services/payola/change_subscription_plan.rb
+++ b/app/services/payola/change_subscription_plan.rb
@@ -1,6 +1,6 @@
 module Payola
   class ChangeSubscriptionPlan
-    def self.call(subscription, plan, quantity = 1, coupon_code = nil)
+    def self.call(subscription, plan, quantity = 1, coupon_code = nil, trial_end = nil)
       secret_key = Payola.secret_key_for_sale(subscription)
       old_plan = subscription.plan
 
@@ -10,6 +10,7 @@ module Payola
         sub.prorate = should_prorate?(subscription, plan, coupon_code)
         sub.coupon = coupon_code if coupon_code.present?
         sub.quantity = quantity
+        sub.trial_end = trial_end if trial_end.present?
         sub.save
 
         subscription.plan = plan

--- a/app/views/payola/subscriptions/_change_plan.html.erb
+++ b/app/views/payola/subscriptions/_change_plan.html.erb
@@ -1,5 +1,7 @@
 <%
   quantity = local_assigns.fetch :quantity, 1
+  coupon = local_assigns.fetch :coupon, nil
+  trial_end = local_assigns.fetch :trial_end, nil
   button_class = local_assigns.fetch :button_class, 'stripe-button-el'
   button_text = local_assigns.fetch :button_text, "Update Plan"
 %>
@@ -8,5 +10,11 @@
   <%= hidden_field_tag 'plan_class', new_plan.plan_class %>
   <%= hidden_field_tag 'plan_id', new_plan.id %>
   <%= hidden_field_tag 'quantity', quantity %>
+  <% if coupon %>
+  <%= hidden_field_tag 'coupon', coupon %>
+  <% end %>
+  <% if trial_end %>
+  <%= hidden_field_tag 'trial_end', trial_end %>
+  <% end %>
   <%= button_tag button_text, class: button_class %>
 <% end %>

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -130,13 +130,14 @@ module Payola
         @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
         @plan = create(:subscription_plan)
         @quantity = 1
+        @coupon = nil
         @trial_end = "now"
       end
 
       it "should call Payola::ChangeSubscriptionPlan and redirect" do
-        expect(Payola::ChangeSubscriptionPlan).to receive(:call).with(@subscription, @plan, @quantity, @trial_end)
+        expect(Payola::ChangeSubscriptionPlan).to receive(:call).with(@subscription, @plan, @quantity, @coupon, @trial_end)
 
-        post :change_plan, params: { guid: @subscription.guid, plan_class: @plan.plan_class, plan_id: @plan.id, trial_end: "now" }
+        post :change_plan, params: { guid: @subscription.guid, plan_class: @plan.plan_class, plan_id: @plan.id, trial_end: @trial_end }
 
         expect(response).to redirect_to "/subdir/payola/confirm_subscription/#{@subscription.guid}"
         expect(request.flash[:notice]).to eq 'Subscription plan updated'

--- a/spec/controllers/payola/subscriptions_controller_spec.rb
+++ b/spec/controllers/payola/subscriptions_controller_spec.rb
@@ -130,12 +130,13 @@ module Payola
         @subscription = create(:subscription, state: :active, stripe_customer_id: Stripe::Customer.create.id)
         @plan = create(:subscription_plan)
         @quantity = 1
+        @trial_end = "now"
       end
 
       it "should call Payola::ChangeSubscriptionPlan and redirect" do
-        expect(Payola::ChangeSubscriptionPlan).to receive(:call).with(@subscription, @plan, @quantity)
+        expect(Payola::ChangeSubscriptionPlan).to receive(:call).with(@subscription, @plan, @quantity, @trial_end)
 
-        post :change_plan, params: { guid: @subscription.guid, plan_class: @plan.plan_class, plan_id: @plan.id }
+        post :change_plan, params: { guid: @subscription.guid, plan_class: @plan.plan_class, plan_id: @plan.id, trial_end: "now" }
 
         expect(response).to redirect_to "/subdir/payola/confirm_subscription/#{@subscription.guid}"
         expect(request.flash[:notice]).to eq 'Subscription plan updated'

--- a/spec/services/payola/change_subscription_plan_spec.rb
+++ b/spec/services/payola/change_subscription_plan_spec.rb
@@ -29,6 +29,37 @@ module Payola
         end
       end
 
+      context "trial_end" do
+        before do
+          @sub = Stripe::Subscription.new
+
+          allow(@sub).to receive(:save).and_return(true) # trial_end value is wiped when save is called
+          allow(ChangeSubscriptionPlan).to receive(:retrieve_subscription_for_customer).and_return(@sub)
+        end
+
+        context "not set" do
+          before do
+            Payola::ChangeSubscriptionPlan.call(@subscription, @plan2)
+          end
+
+          it "should not have trial_end set" do
+            expect(@sub.try(:trial_end)).to be_nil
+          end
+        end
+
+        context "set" do
+          before do
+            @trial_end = "now"
+            @quantity = 1
+            Payola::ChangeSubscriptionPlan.call(@subscription, @plan2, @quantity, nil, @trial_end)
+          end
+
+          it "should have the trial_end" do
+            expect(@sub.trial_end).to eq(@trial_end)
+          end
+        end
+      end
+
       context "coupon" do
         before do
           @sub = Stripe::Subscription.new

--- a/spec/services/payola/change_subscription_plan_spec.rb
+++ b/spec/services/payola/change_subscription_plan_spec.rb
@@ -49,9 +49,10 @@ module Payola
 
         context "set" do
           before do
-            @trial_end = "now"
             @quantity = 1
-            Payola::ChangeSubscriptionPlan.call(@subscription, @plan2, @quantity, nil, @trial_end)
+            @coupon = nil
+            @trial_end = "now"
+            Payola::ChangeSubscriptionPlan.call(@subscription, @plan2, @quantity, @coupon, @trial_end)
           end
 
           it "should have the trial_end" do


### PR DESCRIPTION
When you update the subscription to a different plan with `trial_period_days` set, the plan's trial starts, resulting in an unwanted trial period. I've added the ability to set `trial_end`. Set `trial_end` to `now` if you don't want to use the trial.

> Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer’s trial immediately.
> 
> https://stripe.com/docs/api#update_subscription-trial_end

> Stripe immediately attempts payment for these subscription changes:
> - From a subscription that doesn’t require payment (e.g., due to a trial, free plan, or coupon) to a paid subscription
> - When the billing period changes
> 
> https://stripe.com/docs/subscriptions/upgrading-downgrading

Using `trial_end` will transition the customer into the new plan as usual without the trial period and charge them for the new plan.

## Setup
- set `<%= hidden_field_tag 'trial_end', 'now' %>` in the `change_subscription_plan` form
- I've added the ability to add coupons when you change the plan via `<%= hidden_field_tag 'coupon', 'stripe_coupon_id' %>`

The coupon feature was by accident since it needed to be in the `ChangeSubscriptionPlan.call`, it still defaults to `nil`. 

## Custom Form
`<%= hidden_field_tag 'trial_end', 'now' %>`
`<%= hidden_field_tag 'coupon', 'your_stripe_coupon_id' %>`

## Partial
```
<%= render 'payola/subscriptions/change_plan',
    subscription: @subscription,
    new_plan: @new_plan,
    trial_end: 'now',
    coupon: 'your_stripe_coupon_id',
    quantity: 1 %>
```