### PR TITLE
allow checkout form to override currency

### DIFF
--- a/app/assets/javascripts/payola/form.js
+++ b/app/assets/javascripts/payola/form.js
@@ -26,8 +26,10 @@ var PayolaPaymentForm = {
             var base_path = form.data('payola-base-path');
             var product = form.data('payola-product');
             var permalink = form.data('payola-permalink');
-
+            var currency = form.data('payola-currency');
+  
             var data_form = $('<form></form>');
+            data_form.append($('<input type="hidden" name="currency">').val(currency));
             data_form.append($('<input type="hidden" name="stripeToken">').val(response.id));
             data_form.append($('<input type="hidden" name="stripeEmail">').val(email));
             data_form.append(PayolaPaymentForm.authenticityTokenInput());

--- a/app/services/payola/create_sale.rb
+++ b/app/services/payola/create_sale.rb
@@ -19,7 +19,11 @@ module Payola
         s.email = email
         s.stripe_token = token
         s.affiliate_id = affiliate.try(:id)
-        s.currency = product.respond_to?(:currency) ? product.currency : Payola.default_currency
+        if params[:currency].present?
+          s.currency = params[:currency]
+        else
+          s.currency = product.respond_to?(:currency) ? product.currency : Payola.default_currency
+        end
         s.signed_custom_fields = params[:signed_custom_fields]
         s.stripe_customer_id = customer.id if customer
 


### PR DESCRIPTION
Our product allows for multiple currency that is set at an individual charge level.  This change allows the form to override the currency with a custom form element data-payola-currency='usd'.  