### PR TITLE
pass stripe_customer_id to buy route

### DIFF
--- a/app/assets/javascripts/payola/form.js
+++ b/app/assets/javascripts/payola/form.js
@@ -27,8 +27,10 @@ var PayolaPaymentForm = {
             var product = form.data('payola-product');
             var permalink = form.data('payola-permalink');
             var currency = form.data('payola-currency');
+            var stripe_customer_id = form.data('stripe_customer_id');
   
             var data_form = $('<form></form>');
+            data_form.append($('<input type="hidden" name="stripe_customer_id">').val(stripe_customer_id));
             data_form.append($('<input type="hidden" name="currency">').val(currency));
             data_form.append($('<input type="hidden" name="stripeToken">').val(response.id));
             data_form.append($('<input type="hidden" name="stripeEmail">').val(email));


### PR DESCRIPTION
This change grabs the stripe_customer_id and passes it to the buy route to allow finding the StripeCustomer if one already exists. 
