### PR TITLE
Inherit migrations from ActiveRecord::Migration[4.2] in order to supp…

### DIFF
--- a/db/migrate/20141001170138_create_payola_sales.rb
+++ b/db/migrate/20141001170138_create_payola_sales.rb
@@ -1,4 +1,4 @@
-class CreatePayolaSales < ActiveRecord::Migration
+class CreatePayolaSales < ActiveRecord::Migration[4.2]
   def change
     create_table :payola_sales do |t|
       t.string   "email",         limit: 191

--- a/db/migrate/20141001203541_create_payola_stripe_webhooks.rb
+++ b/db/migrate/20141001203541_create_payola_stripe_webhooks.rb
@@ -1,4 +1,4 @@
-class CreatePayolaStripeWebhooks < ActiveRecord::Migration
+class CreatePayolaStripeWebhooks < ActiveRecord::Migration[4.2]
   def change
     create_table :payola_stripe_webhooks do |t|
       t.string :stripe_id

--- a/db/migrate/20141002013618_create_payola_coupons.rb
+++ b/db/migrate/20141002013618_create_payola_coupons.rb
@@ -1,4 +1,4 @@
-class CreatePayolaCoupons < ActiveRecord::Migration
+class CreatePayolaCoupons < ActiveRecord::Migration[4.2]
   def change
     create_table :payola_coupons do |t|
       t.string :code

--- a/db/migrate/20141002013701_create_payola_affiliates.rb
+++ b/db/migrate/20141002013701_create_payola_affiliates.rb
@@ -1,4 +1,4 @@
-class CreatePayolaAffiliates < ActiveRecord::Migration
+class CreatePayolaAffiliates < ActiveRecord::Migration[4.2]
   def change
     create_table :payola_affiliates do |t|
       t.string :code

--- a/db/migrate/20141002203725_add_stripe_customer_id_to_sale.rb
+++ b/db/migrate/20141002203725_add_stripe_customer_id_to_sale.rb
@@ -1,4 +1,4 @@
-class AddStripeCustomerIdToSale < ActiveRecord::Migration
+class AddStripeCustomerIdToSale < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_sales, :stripe_customer_id, :string, limit: 191
     add_index :payola_sales, :stripe_customer_id

--- a/db/migrate/20141017233304_add_currency_to_payola_sale.rb
+++ b/db/migrate/20141017233304_add_currency_to_payola_sale.rb
@@ -1,4 +1,4 @@
-class AddCurrencyToPayolaSale < ActiveRecord::Migration
+class AddCurrencyToPayolaSale < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_sales, :currency, :string
   end

--- a/db/migrate/20141026101628_add_custom_fields_to_payola_sale.rb
+++ b/db/migrate/20141026101628_add_custom_fields_to_payola_sale.rb
@@ -1,4 +1,4 @@
-class AddCustomFieldsToPayolaSale < ActiveRecord::Migration
+class AddCustomFieldsToPayolaSale < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_sales, :custom_fields, :text
   end

--- a/db/migrate/20141026144800_rename_custom_fields_to_signed_custom_fields_on_payola_sale.rb
+++ b/db/migrate/20141026144800_rename_custom_fields_to_signed_custom_fields_on_payola_sale.rb
@@ -1,4 +1,4 @@
-class RenameCustomFieldsToSignedCustomFieldsOnPayolaSale < ActiveRecord::Migration
+class RenameCustomFieldsToSignedCustomFieldsOnPayolaSale < ActiveRecord::Migration[4.2]
   def change
     rename_column :payola_sales, :custom_fields, :signed_custom_fields
   end

--- a/db/migrate/20141029135848_add_owner_to_payola_sale.rb
+++ b/db/migrate/20141029135848_add_owner_to_payola_sale.rb
@@ -1,4 +1,4 @@
-class AddOwnerToPayolaSale < ActiveRecord::Migration
+class AddOwnerToPayolaSale < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_sales, :owner_id, :integer
     add_column :payola_sales, :owner_type, :string, limit: 100

--- a/db/migrate/20141105043439_create_payola_subscriptions.rb
+++ b/db/migrate/20141105043439_create_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreatePayolaSubscriptions < ActiveRecord::Migration
+class CreatePayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :payola_subscriptions do |t|
       t.string :plan_type

--- a/db/migrate/20141106034610_add_currency_to_payola_subscriptions.rb
+++ b/db/migrate/20141106034610_add_currency_to_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddCurrencyToPayolaSubscriptions < ActiveRecord::Migration
+class AddCurrencyToPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :currency, :string
     add_column :payola_subscriptions, :amount, :integer

--- a/db/migrate/20141107025420_add_guid_to_payola_subscriptions.rb
+++ b/db/migrate/20141107025420_add_guid_to_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddGuidToPayolaSubscriptions < ActiveRecord::Migration
+class AddGuidToPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :guid, :string, limit: 191
     add_index :payola_subscriptions, :guid

--- a/db/migrate/20141109203101_add_stripe_status_to_payola_subscription.rb
+++ b/db/migrate/20141109203101_add_stripe_status_to_payola_subscription.rb
@@ -1,4 +1,4 @@
-class AddStripeStatusToPayolaSubscription < ActiveRecord::Migration
+class AddStripeStatusToPayolaSubscription < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :stripe_status, :string
   end

--- a/db/migrate/20141112024805_add_affiliate_id_to_payola_subscriptions.rb
+++ b/db/migrate/20141112024805_add_affiliate_id_to_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddAffiliateIdToPayolaSubscriptions < ActiveRecord::Migration
+class AddAffiliateIdToPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :affiliate_id, :integer
   end

--- a/db/migrate/20141114032013_add_coupon_code_to_payola_subscriptions.rb
+++ b/db/migrate/20141114032013_add_coupon_code_to_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddCouponCodeToPayolaSubscriptions < ActiveRecord::Migration
+class AddCouponCodeToPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :coupon, :string
   end

--- a/db/migrate/20141114154223_add_signed_custom_fields_to_payola_subscription.rb
+++ b/db/migrate/20141114154223_add_signed_custom_fields_to_payola_subscription.rb
@@ -1,4 +1,4 @@
-class AddSignedCustomFieldsToPayolaSubscription < ActiveRecord::Migration
+class AddSignedCustomFieldsToPayolaSubscription < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :signed_custom_fields, :text
   end

--- a/db/migrate/20141114163841_add_addresses_to_payola_subscription.rb
+++ b/db/migrate/20141114163841_add_addresses_to_payola_subscription.rb
@@ -1,4 +1,4 @@
-class AddAddressesToPayolaSubscription < ActiveRecord::Migration
+class AddAddressesToPayolaSubscription < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :customer_address, :text
     add_column :payola_subscriptions, :business_address, :text

--- a/db/migrate/20141122020755_add_setup_fee_to_payola_subscriptions.rb
+++ b/db/migrate/20141122020755_add_setup_fee_to_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddSetupFeeToPayolaSubscriptions < ActiveRecord::Migration
+class AddSetupFeeToPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :setup_fee, :integer
   end

--- a/db/migrate/20141213205847_add_active_to_payola_coupon.rb
+++ b/db/migrate/20141213205847_add_active_to_payola_coupon.rb
@@ -1,4 +1,4 @@
-class AddActiveToPayolaCoupon < ActiveRecord::Migration
+class AddActiveToPayolaCoupon < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_coupons, :active, :boolean, default: true
   end

--- a/db/migrate/20150930164135_add_tax_percent_to_payola_subscriptions.rb
+++ b/db/migrate/20150930164135_add_tax_percent_to_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddTaxPercentToPayolaSubscriptions < ActiveRecord::Migration
+class AddTaxPercentToPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :payola_subscriptions, :tax_percent, :integer
   end

--- a/db/migrate/20151205004838_change_tax_percent_format_in_payola_subscriptions.rb
+++ b/db/migrate/20151205004838_change_tax_percent_format_in_payola_subscriptions.rb
@@ -1,4 +1,4 @@
-class ChangeTaxPercentFormatInPayolaSubscriptions < ActiveRecord::Migration
+class ChangeTaxPercentFormatInPayolaSubscriptions < ActiveRecord::Migration[4.2]
   def up
     change_column :payola_subscriptions, :tax_percent, :decimal, :precision => 4, :scale => 2
   end


### PR DESCRIPTION
…ort rails 5.1

Rails 5.1 won't allow to use migrations inherited from `ActiveRecord::Migration`