### PR TITLE
set optional:true on all non-presence validated belongs_to associations

### DIFF
--- a/app/models/payola/sale.rb
+++ b/app/models/payola/sale.rb
@@ -12,10 +12,10 @@ module Payola
     validates_presence_of :stripe_token
     validates_presence_of :currency
 
-    belongs_to :product, polymorphic: true
-    belongs_to :owner, polymorphic: true, optional: true
-    belongs_to :coupon, optional: true
-    belongs_to :affiliate, optional: true
+    belongs_to :product, Rails::VERSION::MAJOR > 4 ? { polymorphic: true, optional: true } : { polymorphic: true }
+    belongs_to :owner, Rails::VERSION::MAJOR > 4 ? { polymorphic: true, optional: true } : { polymorphic: true }
+    belongs_to :coupon, Rails::VERSION::MAJOR > 4 ? { optional: true } : {}
+    belongs_to :affiliate, Rails::VERSION::MAJOR > 4 ? { optional: true } : {}
 
     include AASM
 

--- a/app/models/payola/sale.rb
+++ b/app/models/payola/sale.rb
@@ -13,9 +13,9 @@ module Payola
     validates_presence_of :currency
 
     belongs_to :product, polymorphic: true
-    belongs_to :owner, polymorphic: true
-    belongs_to :coupon
-    belongs_to :affiliate
+    belongs_to :owner, polymorphic: true, optional: true
+    belongs_to :coupon, optional: true
+    belongs_to :affiliate, optional: true
 
     include AASM
 

--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -13,9 +13,9 @@ module Payola
     validate :conditional_stripe_token
     validates_presence_of :currency
 
-    belongs_to :plan,  polymorphic: true
-    belongs_to :owner, polymorphic: true, optional: true
-    belongs_to :affiliate, optional: true
+    belongs_to :plan, Rails::VERSION::MAJOR > 4 ? { polymorphic: true, optional: true } : { polymorphic: true }
+    belongs_to :owner, Rails::VERSION::MAJOR > 4 ? { polymorphic: true, optional: true } : { polymorphic: true }
+    belongs_to :affiliate, Rails::VERSION::MAJOR > 4 ? { optional: true } : {}
 
     has_many :sales, class_name: 'Payola::Sale', as: :owner
 

--- a/app/models/payola/subscription.rb
+++ b/app/models/payola/subscription.rb
@@ -14,8 +14,8 @@ module Payola
     validates_presence_of :currency
 
     belongs_to :plan,  polymorphic: true
-    belongs_to :owner, polymorphic: true
-    belongs_to :affiliate
+    belongs_to :owner, polymorphic: true, optional: true
+    belongs_to :affiliate, optional: true
 
     has_many :sales, class_name: 'Payola::Sale', as: :owner
 

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -16,7 +16,7 @@ if Rails::VERSION::MAJOR == 5
   ActiveSupport.to_time_preserves_timezone = true
 
   # Require `belongs_to` associations by default. Previous versions had false.
-  # Rails.application.config.active_record.belongs_to_required_by_default = true
+  Rails.application.config.active_record.belongs_to_required_by_default = true
 
   # Do not halt callback chains when a callback returns false. Previous versions had true.
   ActiveSupport.halt_callback_chains_on_return_false = false


### PR DESCRIPTION
This fixes #259 - with rails 5.1 this is now a breaking issue in upgrading from 5.0 -> 5.1.

Any belongs_to that didn't have presence validation already on the model now has optional: true & and the dummy app config default is enabled as well.

Hopefully I didn't miss anything...