### PR TITLE
Reset subscription cancel_at_period_end on plan change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to Payola will be documented in this file.
 
 ### Enhancements
 - Support Turbolinks & non-Turbolinks apps reliably. #254
-- added support to `ChangeSubscriptionPlan` for `trial_end` and `coupon`
+- Added support to `ChangeSubscriptionPlan` for `trial_end` and `coupon`
+- Reset subscription `cancel_at_period_end` in `ChangeSubscriptionPlan`
 - Remove `spec/` and `.gitignored` files from `gemspec.files`. #293
 - Allow checkout form to override currency. #296
 

--- a/app/services/payola/change_subscription_plan.rb
+++ b/app/services/payola/change_subscription_plan.rb
@@ -13,6 +13,7 @@ module Payola
         sub.trial_end = trial_end if trial_end.present?
         sub.save
 
+        subscription.cancel_at_period_end = false
         subscription.plan = plan
         subscription.quantity = quantity
         subscription.save!


### PR DESCRIPTION
When subscription plan changes, Stripe resets `cancel_at_period_end` (see https://stripe.com/docs/subscriptions/canceling-pausing#reactivating-canceled-subscriptions) but Payola doesn't do the same.
This pull request fixes that.