### PR TITLE
#335 Payola.reset! uses StripeEvent.event_filter instead of event_retriever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Payola adheres to [Semantic Versioning](http://semver.org/).
 
 All notable changes to Payola will be documented in this file.
 
+### Bug Fixes
+- Change `Payola.reset!` to use `StripeEvent.event_filter` rather than `event_retriever`. #335
+
 ## v1.5.1 - 2017-11-25
 [Full Changelog](https://github.com/peterkeen/payola/compare/v1.5.0...v1.5.1)
 
@@ -19,7 +22,6 @@ All notable changes to Payola will be documented in this file.
 
 ### Bug Fixes
 - `PayolaPaymentForm.poll()` handles HTTP error responses. #310
-
 
 ## v1.5.0 - 2016-10-27
 [Full Changelog](https://github.com/peterkeen/payola/compare/v1.4.0...v1.5.0)

--- a/lib/payola.rb
+++ b/lib/payola.rb
@@ -73,7 +73,7 @@ module Payola
     end
 
     def reset!
-      StripeEvent.event_retriever = Retriever
+      StripeEvent.event_filter = Retriever
       Stripe.api_version = ENV['STRIPE_API_VERSION'] || '2015-02-18'
 
       self.background_worker = nil

--- a/payola.gemspec
+++ b/payola.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.1"
   s.add_dependency "jquery-rails"
-  s.add_dependency "stripe", ">= 1.20.1"
+  s.add_dependency "stripe", ">= 2.8"
   s.add_dependency "aasm", ">= 4.0.7"
-  s.add_dependency "stripe_event", ">= 1.3.0"
+  s.add_dependency "stripe_event", ">= 2.0.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
## What does this PR do?
Fixes an error being thrown when running `rails g payola:install` which was caused by an update to the `stripe_event` gem where `StripeEvent.event_retriever` was changed to `event_filter`. #335 

## Test coverage
Tests were originally failing and are now passing, and the installation completed without an error. I didn't add any new tests as I assume the integration with the `stripe_event` gem is fully covered by the existing tests and that if this fix wasn't sufficient, tests would be failing.