### PR TITLE
Added stripe.js version 3 to stripe header

### DIFF
--- a/app/views/payola/transactions/_stripe_header.html.erb
+++ b/app/views/payola/transactions/_stripe_header.html.erb
@@ -1,4 +1,5 @@
 <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+<script type="text/javascript" src="https://js.stripe.com/v3/"></script>
 <script type="text/javascript">
   Stripe.setPublishableKey("<%= Payola.publishable_key %>");
 </script>


### PR DESCRIPTION
Added stripe.js version 3 to stripe header. Stripe js version 3 allows for the use of Stripe Elements for checkout forms.